### PR TITLE
Resolve SVG, with a drop in resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dom": "16.0.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-28.0.0.tar.gz",
     "react-native-dotenv": "^0.1.1",
+    "react-native-svg-web": "^1.0.1",
     "react-native-web": "^0.7.0",
     "react-navigation": "^1.1.0-rc.4",
     "react-scripts": "1.0.17",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -126,6 +126,7 @@ module.exports = {
       '@expo/vector-icons': 'expo-web',
       expo: 'expo-web',
       'react-native': 'react-native-web',
+      'react-native-svg': 'react-native-svg-web',
     },
   },
 };


### PR DESCRIPTION
Hey, not sure how you want to approach this. Using third party libraries like `react-native-svg` breaks the render. Should we add the well known package resolves like this? What do you think?

Not even sure if this is an upstream tho.